### PR TITLE
add aws client

### DIFF
--- a/platform_operator/aws_client.py
+++ b/platform_operator/aws_client.py
@@ -1,0 +1,53 @@
+from typing import Any, Dict, Optional
+
+import aiobotocore
+from yarl import URL
+
+
+class AwsElbClient:
+    _session = aiobotocore.get_session()
+
+    def __init__(
+        self,
+        region: str,
+        access_key_id: str = "",
+        secret_access_key: str = "",
+        endpoint_url: Optional[URL] = None,
+    ) -> None:
+        self._region = region
+        self._access_key_id = access_key_id
+        self._secret_access_key = secret_access_key
+        self._endpoint_url = endpoint_url
+
+    async def __aenter__(self, *args: Any, **kwargs: Any) -> "AwsElbClient":
+        # On AWS the nodes will be configured to assume the correct role and no
+        # credentials need to be passed.
+        kwargs = {}
+        if self._access_key_id:
+            kwargs["aws_access_key_id"] = self._access_key_id
+        if self._secret_access_key:
+            kwargs["aws_secret_access_key"] = self._secret_access_key
+        if self._endpoint_url:
+            kwargs["endpoint_url"] = str(self._endpoint_url)
+        context = self._session.create_client("elb", region_name=self._region, **kwargs)
+        self._client = await context.__aenter__()
+        return self
+
+    async def __aexit__(self, *args: Any, **kwargs: Any) -> None:
+        await self._client.close()
+
+    async def create_load_balancer(self, **kwargs: Any) -> Dict[str, str]:
+        return await self._client.create_load_balancer(**kwargs)
+
+    async def delete_load_balancer(self, **kwargs: Any) -> None:
+        await self._client.delete_load_balancer(**kwargs)
+
+    async def get_load_balancer_by_dns_name(
+        self, dns_name: str
+    ) -> Optional[Dict[str, Any]]:
+        paginator = self._client.get_paginator("describe_load_balancers")
+        async for page in paginator.paginate():
+            for lb in page.get("LoadBalancerDescriptions", []):
+                if lb["DNSName"] == dns_name:
+                    return lb
+        return None

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -6,3 +6,6 @@ black==19.10b0
 pytest==5.4.1
 pytest-aiohttp==0.3.0
 pytest-asyncio==0.12.0
+boto3==1.12.32
+botocore==1.15.32
+moto[server]==1.3.14

--- a/setup.cfg
+++ b/setup.cfg
@@ -43,3 +43,6 @@ ignore_missing_imports = true
 
 [mypy-kopf.*]
 ignore_missing_imports = true
+
+[mypy-aiobotocore.*]
+ignore_missing_imports = true

--- a/setup.py
+++ b/setup.py
@@ -6,6 +6,7 @@ install_requires = (
     "aiohttp==3.6.2",
     "pyyaml==5.3.1",
     "idna==2.8",
+    "aiobotocore==1.0.4",
 )
 
 setup(

--- a/tests/integration/aws.py
+++ b/tests/integration/aws.py
@@ -1,0 +1,80 @@
+import os
+import threading
+from contextlib import contextmanager
+from dataclasses import dataclass
+from typing import Any, AsyncIterator, Dict, Iterator
+
+import moto.server
+import pytest
+from werkzeug.serving import make_server
+from yarl import URL
+
+from platform_operator.aws_client import AwsElbClient
+
+
+@dataclass(frozen=True)
+class AppAddress:
+    host: str
+    port: int
+
+
+class AppServer(threading.Thread):
+    def __init__(self, app: Any, app_address: AppAddress):
+        threading.Thread.__init__(self)
+        self._server = make_server(
+            host=app_address.host, port=app_address.port, app=app, threaded=False
+        )
+
+    def run(self) -> None:
+        self._server.serve_forever()
+
+    def shutdown(self) -> None:
+        self._server.shutdown()
+
+
+@contextmanager
+def create_app_server(app: Any, port: int = 8080) -> Iterator[AppAddress]:
+    app_address = AppAddress("0.0.0.0", port)
+    app_server = AppServer(app, app_address)
+    try:
+        app_server.start()
+        yield app_address
+    finally:
+        app_server.shutdown()
+
+
+@pytest.fixture(scope="session")
+def elb_endpoint_url() -> Iterator[URL]:
+    app = moto.server.DomainDispatcherApplication(
+        moto.server.create_backend_app, service="elb"
+    )
+    with create_app_server(app, port=5000) as api_address:
+        yield URL(f"http://{api_address.host}:{api_address.port}")
+
+
+@pytest.fixture(scope="session")
+def aws_config() -> Dict[str, str]:
+    os.environ["AWS_DEFAULT_REGION"] = "us-east-1"
+    os.environ["AWS_ACCESS_KEY_ID"] = "testing"
+    os.environ["AWS_SECRET_ACCESS_KEY"] = "testing"
+    os.environ["AWS_SECURITY_TOKEN"] = "testing"
+    os.environ["AWS_SESSION_TOKEN"] = "testing"
+
+    return {
+        "region": "us-east-1",
+        "access_key_id": "testing",
+        "secret_access_key": "testing",
+    }
+
+
+@pytest.fixture
+async def elb_client(
+    aws_config: Dict[str, str], elb_endpoint_url: URL
+) -> AsyncIterator[AwsElbClient]:
+    async with AwsElbClient(
+        region=aws_config["region"],
+        access_key_id=aws_config["access_key_id"],
+        secret_access_key=aws_config["secret_access_key"],
+        endpoint_url=elb_endpoint_url,
+    ) as client:
+        yield client

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,1 +1,1 @@
-pytest_plugins = ["tests.integration.kube"]
+pytest_plugins = ["tests.integration.kube", "tests.integration.aws"]

--- a/tests/integration/test_aws_client.py
+++ b/tests/integration/test_aws_client.py
@@ -1,0 +1,39 @@
+import uuid
+from typing import Any, AsyncIterator, Dict
+
+import pytest
+
+from platform_operator.aws_client import AwsElbClient
+
+
+class TestAwsElbClient:
+    @pytest.fixture
+    async def load_balancer(
+        self, elb_client: AwsElbClient
+    ) -> AsyncIterator[Dict[str, Any]]:
+        name = str(uuid.uuid4())
+        response = await elb_client.create_load_balancer(
+            LoadBalancerName=name,
+            Listeners=[
+                {
+                    "Protocol": "string",
+                    "LoadBalancerPort": 123,
+                    "InstanceProtocol": "string",
+                    "InstancePort": 123,
+                    "SSLCertificateId": "string",
+                }
+            ],
+        )
+        yield {"LoadBalancerName": name, "DNSName": response["DNSName"]}
+        await elb_client.delete_load_balancer(LoadBalancerName=name)
+
+    @pytest.mark.asyncio
+    async def test_get_load_balancer_by_dns_name(
+        self, load_balancer: Dict[str, Any], elb_client: AwsElbClient
+    ) -> None:
+        result = await elb_client.get_load_balancer_by_dns_name(
+            load_balancer["DNSName"]
+        )
+
+        assert result
+        assert result["LoadBalancerName"] == load_balancer["LoadBalancerName"]


### PR DESCRIPTION
AWS ELB client is needed for AWS cluster to get load balancers hosted zones. (AWS creates dns name and hosted zone for each load balancer).