### PR TITLE
add consul client

### DIFF
--- a/platform_operator/consul_client.py
+++ b/platform_operator/consul_client.py
@@ -1,0 +1,200 @@
+import asyncio
+import logging
+import time
+from contextlib import asynccontextmanager
+from types import SimpleNamespace
+from typing import Any, AsyncIterator, Dict, Optional, Sequence, Union
+
+import aiohttp
+from yarl import URL
+
+
+logger = logging.getLogger(__name__)
+
+
+class SessionExpiredError(Exception):
+    pass
+
+
+class LockAcquisitionError(Exception):
+    pass
+
+
+class LockReleaseError(Exception):
+    pass
+
+
+class ConsulClient:
+    def __init__(self, url: URL) -> None:
+        self._url = url
+        self._client: Optional[aiohttp.ClientSession] = None
+
+    async def _on_request_start(
+        self,
+        session: aiohttp.ClientSession,
+        trace_config_ctx: SimpleNamespace,
+        params: aiohttp.TraceRequestStartParams,
+    ) -> None:
+        logger.info("Sending %s %s", params.method, params.url)
+
+    async def _on_request_end(
+        self,
+        session: aiohttp.ClientSession,
+        trace_config_ctx: SimpleNamespace,
+        params: aiohttp.TraceRequestEndParams,
+    ) -> None:
+        if 400 <= params.response.status:
+            logger.warning(
+                "Received %s %s %s\n%s",
+                params.method,
+                params.response.status,
+                params.url,
+                await params.response.text(),
+            )
+        else:
+            logger.info(
+                "Received %s %s %s",
+                params.method,
+                params.response.status,
+                params.url,
+            )
+
+    async def __aenter__(self) -> "ConsulClient":
+        trace_config = aiohttp.TraceConfig()
+        trace_config.on_request_start.append(self._on_request_start)
+        trace_config.on_request_end.append(self._on_request_end)
+        self._client = aiohttp.ClientSession(trace_configs=[trace_config])
+        return self
+
+    async def __aexit__(self, *args: Any, **kwargs: Any) -> None:
+        await self.close()
+
+    async def close(self) -> None:
+        assert self._client
+        await self._client.close()
+
+    async def get_key(
+        self, key: str, *, recurse: bool = False, raw: bool = False
+    ) -> Union[Sequence[Dict[str, Any]], bytes]:
+        assert self._client
+        query = {}
+        if recurse:
+            query["recurse"] = "true"
+        if raw:
+            query["raw"] = "true"
+        async with self._client.get(
+            (self._url / "v1/kv" / key).with_query(query or None)
+        ) as response:
+            response.raise_for_status()
+            if raw:
+                return await response.read()
+            payload = await response.json()
+            return payload
+
+    async def put_key(
+        self, key: str, value: bytes, *, acquire: str = "", release: str = ""
+    ) -> bool:
+        assert self._client
+        query = {}
+        if acquire:
+            query["acquire"] = acquire
+        if release:
+            query["release"] = release
+        async with self._client.put(
+            (self._url / "v1/kv" / key).with_query(query or None), data=value
+        ) as response:
+            response.raise_for_status()
+            text = await response.text()
+            return text.strip() == "true"
+
+    async def delete_key(self, key: str) -> bool:
+        assert self._client
+        async with self._client.delete(self._url / "v1/kv" / key) as response:
+            response.raise_for_status()
+            text = await response.text()
+            return text.strip() == "true"
+
+    async def get_sessions(self) -> Sequence[Dict[str, Any]]:
+        assert self._client
+        async with self._client.get(self._url / "v1/session/list") as response:
+            response.raise_for_status()
+            payload = await response.json()
+            return payload
+
+    async def create_session(
+        self,
+        *,
+        ttl_s: int,
+        lock_delay_s: Optional[int] = None,
+        name: str = "",
+        behavior: str = "",
+    ) -> str:
+        assert self._client
+        assert ttl_s >= 10
+        assert not lock_delay_s or lock_delay_s > 0
+        payload = {"TTL": f"{ttl_s}s"}
+        if name:
+            payload["Name"] = name
+        if behavior:
+            payload["Behavior"] = behavior
+        if lock_delay_s:
+            payload["LockDelay"] = f"{lock_delay_s}s"
+        async with self._client.put(
+            self._url / "v1/session/create", json=payload
+        ) as response:
+            response.raise_for_status()
+            payload = await response.json()
+            return payload["ID"]
+
+    async def delete_session(self, session_id: str) -> bool:
+        assert self._client
+        async with self._client.put(
+            self._url / "v1/session/destroy" / session_id
+        ) as response:
+            response.raise_for_status()
+            text = await response.text()
+            return text.strip() == "true"
+
+    @asynccontextmanager
+    async def lock_key(
+        self,
+        key: str,
+        value: bytes,
+        *,
+        ttl_s: int,
+        lock_delay_s: Optional[int] = None,
+        sleep_s: float = 0.1,
+        timeout_s: Optional[float] = None,
+    ) -> AsyncIterator[None]:
+        session_id = await self.create_session(ttl_s=ttl_s, lock_delay_s=lock_delay_s)
+        logger.info("Session %r created", session_id)
+
+        try:
+            start_time = time.monotonic()
+            while True:
+                acquired = await self.put_key(key, value, acquire=session_id)
+                if acquired:
+                    break
+                elapsed_s = time.monotonic() - start_time
+                if timeout_s and elapsed_s + sleep_s >= timeout_s:
+                    logger.warning(
+                        "Failed to acquire lock (%r, %r) before timeout",
+                        session_id,
+                        key,
+                    )
+                    raise LockAcquisitionError("Failed to acquire lock before timeout")
+                await asyncio.sleep(sleep_s)
+            logger.info("Lock (%r, %r) acquired", session_id, key)
+            start_time = time.monotonic()  # lock start time
+            yield
+            elapsed_s = time.monotonic() - start_time
+            if elapsed_s >= ttl_s:
+                logger.warning("Lock (%r, %r) expired", session_id, key)
+                raise SessionExpiredError(f"Session {session_id!r} expired")
+            logger.info("Lock (%r, %r) released", session_id, key)
+        finally:
+            released = await self.delete_session(session_id)
+            if not released:
+                logger.warning("Failed to destroy session %r", session_id)
+                raise LockReleaseError(f"Failed to destroy session {session_id!r}")
+            logger.info("Session %r destroyed", session_id)

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,0 +1,18 @@
+from typing import AsyncIterator
+
+import pytest
+from yarl import URL
+
+from platform_operator.consul_client import ConsulClient
+from platform_operator.helm_client import HelmClient
+
+
+@pytest.fixture
+async def helm_client(kube_context: str) -> HelmClient:
+    return HelmClient(kube_context=kube_context)
+
+
+@pytest.fixture
+async def consul_client() -> AsyncIterator[ConsulClient]:
+    async with ConsulClient(URL("http://localhost:8500")) as client:
+        yield client

--- a/tests/integration/docker/docker-compose.yaml
+++ b/tests/integration/docker/docker-compose.yaml
@@ -1,0 +1,18 @@
+version: "3"
+services:
+
+  consul:
+    container_name: consul
+    image: consul:latest
+    ports:
+      - 8500:8500
+    healthcheck:
+      test:
+        - CMD
+        - /bin/sh
+        - -ec
+        - curl http://127.0.0.1:8500/v1/status/leader 2>/dev/null | grep -E '".+"'
+      interval: 5s
+      timeout: 30s
+      retries: 3
+    user: root

--- a/tests/integration/test_consul_client.py
+++ b/tests/integration/test_consul_client.py
@@ -1,0 +1,118 @@
+import asyncio
+import collections.abc
+
+import pytest
+
+from platform_operator.consul_client import ConsulClient, SessionExpiredError
+
+
+class TestConsulClient:
+    @pytest.mark.asyncio
+    async def test_get_key(self, consul_client: ConsulClient) -> None:
+        assert await consul_client.put_key("key/1", b"value1")
+        result = await consul_client.get_key("key/1")
+        assert isinstance(result, collections.abc.Sequence)
+        assert isinstance(result[0], dict)
+        assert result[0]["Value"] == "dmFsdWUx"
+
+        assert await consul_client.put_key("key/2", b"value2")
+        result = await consul_client.get_key("key/2", raw=True)
+        assert isinstance(result, bytes)
+        assert result == b"value2"
+
+        result = await consul_client.get_key("key", recurse=True)
+        assert isinstance(result, collections.Sequence)
+        assert isinstance(result[0], dict)
+        assert isinstance(result[1], dict)
+        assert result[0]["Value"] == "dmFsdWUx"
+        assert result[1]["Value"] == "dmFsdWUy"
+
+    @pytest.mark.asyncio
+    async def test_delete_key(self, consul_client: ConsulClient) -> None:
+        assert await consul_client.put_key("key", b"value")
+        assert await consul_client.delete_key("key")
+
+    @pytest.mark.asyncio
+    async def test_get_sessions(self, consul_client: ConsulClient) -> None:
+        session_id = await consul_client.create_session(ttl_s=10, name="test")
+        result = await consul_client.get_sessions()
+
+        assert any(r["ID"] == session_id and r["Name"] == "test" for r in result)
+
+    @pytest.mark.asyncio
+    async def test_delete_session(self, consul_client: ConsulClient) -> None:
+        session_id = await consul_client.create_session(ttl_s=10, name="test")
+        assert await consul_client.delete_session(session_id)
+
+    @pytest.mark.asyncio
+    async def test_sequential_lock(self, consul_client: ConsulClient) -> None:
+        result = []
+        i = 0
+
+        await consul_client.delete_key("lock")
+
+        async def run(delay_s: float) -> None:
+            async with consul_client.lock_key(
+                "lock", b"value", ttl_s=10, lock_delay_s=1, sleep_s=0.5, timeout_s=5
+            ):
+                nonlocal i
+                i += 1
+                result.append(f"{i} start")
+                if delay_s:
+                    await asyncio.sleep(delay_s)
+                result.append(f"{i} end")
+
+        await asyncio.wait(
+            [
+                run(delay_s=1),
+                run(delay_s=0.5),
+                run(delay_s=0),
+            ]
+        )
+
+        assert result == ["1 start", "1 end", "2 start", "2 end", "3 start", "3 end"]
+
+    @pytest.mark.asyncio
+    async def test_expired_lock(self, consul_client: ConsulClient) -> None:
+        await consul_client.delete_key("lock")
+
+        async def run_expired() -> None:
+            with pytest.raises(SessionExpiredError):
+                async with consul_client.lock_key(
+                    "lock", b"value", ttl_s=10, lock_delay_s=1
+                ):
+                    await asyncio.sleep(10.1)
+
+        async def run() -> None:
+            async with consul_client.lock_key(
+                "lock", b"value", ttl_s=10, lock_delay_s=1
+            ):
+                pass
+
+        asyncio.create_task(run_expired())
+
+        await asyncio.sleep(1)
+        await asyncio.wait_for(run(), 11.1)  # ttl + lock_delay + 0.1
+
+    @pytest.mark.asyncio
+    async def test_lock_raises_error(self, consul_client: ConsulClient) -> None:
+        await consul_client.delete_key("lock")
+
+        async def run_raise() -> None:
+            async with consul_client.lock_key(
+                "lock", b"value", ttl_s=10, lock_delay_s=1
+            ):
+                raise Exception("error inside lock")
+
+        async def run() -> None:
+            async with consul_client.lock_key(
+                "lock", b"value", ttl_s=10, lock_delay_s=1, timeout_s=1.1
+            ):
+                pass
+
+        with pytest.raises(Exception, match="error inside lock"):
+            await run_raise()
+
+        # lock should be immediately released after exception
+
+        await asyncio.wait_for(run(), 1.1)  # lock_delay + 0.1

--- a/tests/integration/test_helm_client.py
+++ b/tests/integration/test_helm_client.py
@@ -9,11 +9,6 @@ from platform_operator.models import HelmRepo
 
 
 @pytest.fixture
-async def helm_client(kube_context: str) -> HelmClient:
-    return HelmClient(kube_context=kube_context)
-
-
-@pytest.fixture
 def config_map() -> Dict[str, Any]:
     return {
         "apiVersion": "v1",


### PR DESCRIPTION
Introduced implementation of distributed lock using Consul.
Distributed lock will be needed to forbid simultaneous deploys of `platform-operator` and `platform` helm charts. If `platform-operator` is deployed then operator pod will be restarted and `platform` helm chart upgrade will be interrupted in the middle of deploy. This can lead crashed states of helm release which can be fixed only manually.