### PR TITLE
move consul to operator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,4 +130,4 @@ dmypy.json
 
 .vscode/
 
-/temp_deploy
+temp_deploy/

--- a/Makefile
+++ b/Makefile
@@ -56,6 +56,7 @@ helm_install:
 	helm plugin install https://github.com/belitre/helm-push-artifactory-plugin
 
 helm_repo_add:
+	helm repo add hashicorp https://helm.releases.hashicorp.com
 	@helm repo add neuro https://neuro.jfrog.io/artifactory/helm-virtual-public \
 		--username ${ARTIFACTORY_USERNAME} \
 		--password ${ARTIFACTORY_PASSWORD}
@@ -77,6 +78,7 @@ _helm_fetch:
 	mkdir -p temp_deploy/$(HELM_CHART)
 	cp -Rf deploy/$(HELM_CHART) temp_deploy/
 	find temp_deploy/$(HELM_CHART) -type f -name 'values*' -delete
+	helm dependency update temp_deploy/$(HELM_CHART)
 
 _helm_expand_vars:
 	export IMAGE_REPO=$(ARTIFACTORY_IMAGE_REPO); \

--- a/deploy/platform-operator/requirements.yaml
+++ b/deploy/platform-operator/requirements.yaml
@@ -1,0 +1,5 @@
+dependencies:
+  - name: consul
+    version: "0.29.0"
+    repository: "@hashicorp"
+    condition: consulEnabled

--- a/deploy/platform-operator/templates/_helpers.tpl
+++ b/deploy/platform-operator/templates/_helpers.tpl
@@ -21,3 +21,11 @@ chart: {{ include "platformOperator.chart" . }}
 heritage: {{ .Release.Service | quote }}
 release: {{ .Release.Name | quote }}
 {{- end -}}
+
+{{- define "platformOperator.consul.url" -}}
+{{- if .Values.consulEnabled -}}
+http://consul-server:8500
+{{- else -}}
+http://platform-consul:8500
+{{- end -}}
+{{- end -}}

--- a/deploy/platform-operator/templates/controller-deployment.yaml
+++ b/deploy/platform-operator/templates/controller-deployment.yaml
@@ -71,6 +71,12 @@ spec:
           value: {{ .Values.platform.apiUrl }}
         - name: NP_PLATFORM_NAMESPACE
           value: {{ .Release.Namespace }}
+        - name: NP_CONSUL_URL
+          value: {{ include "platformOperator.consul.url" . | quote }}
+        {{- if .Values.consulEnabled }}
+        - name: NP_CONSUL_INSTALLED
+          value: {{ .Values.consulEnabled | quote }}
+        {{- end }}
         ports:
         - name: liveness-port
           containerPort: 8080

--- a/deploy/platform-operator/values-template.yaml
+++ b/deploy/platform-operator/values-template.yaml
@@ -18,3 +18,20 @@ platform:
   ingressAuthUrl: https://staging.neu.ro
   configUrl: https://staging.neu.ro
   apiUrl: https://staging.neu.ro
+
+# For backward compatibility with old clusters set to `false`
+consulEnabled: true
+
+consul:
+  global:
+    enabled: false
+    image: $DOCKER_SERVER/hashicorp/consul:1.9.2
+
+  nameOverride: consul
+  fullnameOverride: consul
+
+  server:
+    enabled: true
+
+  ui:
+    enabled: true

--- a/deploy/platform/requirements.yaml
+++ b/deploy/platform/requirements.yaml
@@ -1,8 +1,4 @@
 dependencies:
-  - name: consul
-    version: "3.6.0"
-    repository: "@neuro"
-    condition: ingressController.enabled
   - name: traefik
     version: "1.85.1"
     repository: "@stable"
@@ -72,3 +68,9 @@ dependencies:
     - gcp
     - aws
     - azure
+
+  # Deprecated, left for backward compatibility with old clusters
+  - name: consul
+    version: "3.6.0"
+    repository: "@neuro"
+    condition: consulEnabled

--- a/deploy/platform/values-template.yaml
+++ b/deploy/platform/values-template.yaml
@@ -41,6 +41,8 @@ ingress: {}
 ingressController:
   enabled: true
 
+consulEnabled: false
+
 jobs:
   namespace:
     create: true

--- a/platform_operator/handlers.py
+++ b/platform_operator/handlers.py
@@ -59,7 +59,7 @@ async def startup(settings: kopf.OperatorSettings, **kwargs: Any) -> None:
         ConfigClient(config.platform_config_url)
     )
     app.consul_client = await app.exit_stack.enter_async_context(
-        ConsulClient(config.platform_consul_url)
+        ConsulClient(config.consul_url)
     )
     app.certificate_store = CertificateStore(app.consul_client)
 

--- a/platform_operator/helm_values.py
+++ b/platform_operator/helm_values.py
@@ -38,6 +38,7 @@ class HelmValuesFactory:
                 "registryHost": platform.ingress_registry_url.host,
             },
             "ingressController": {"enabled": platform.ingress_controller_enabled},
+            "consulEnabled": platform.consul_install,
             "jobs": {
                 "namespace": {
                     "create": platform.jobs_namespace_create,
@@ -48,7 +49,6 @@ class HelmValuesFactory:
             self._chart_names.adjust_inotify: self.create_adjust_inotify_values(
                 platform
             ),
-            self._chart_names.consul: self.create_consul_values(platform),
             self._chart_names.traefik: self.create_traefik_values(platform),
             self._chart_names.platform_storage: self.create_platform_storage_values(
                 platform
@@ -82,6 +82,8 @@ class HelmValuesFactory:
             }
         else:
             result["dockerConfigSecret"] = {"create": False}
+        if platform.consul_install:
+            result[self._chart_names.consul] = self.create_consul_values(platform)
         if not platform.on_prem:
             result[
                 self._chart_names.platform_object_storage
@@ -289,7 +291,7 @@ class HelmValuesFactory:
             "kvprovider": {
                 "consul": {
                     "watch": True,
-                    "endpoint": f"{self._release_names.platform}-consul:8500",
+                    "endpoint": str(platform.consul_url),
                     "prefix": "traefik",
                 },
                 "storeAcme": True,

--- a/platform_operator/models.py
+++ b/platform_operator/models.py
@@ -126,7 +126,8 @@ class Config:
     platform_config_url: URL
     platform_api_url: URL
     platform_namespace: str
-    platform_consul_url: URL
+    consul_url: URL
+    consul_installed: bool
 
     @classmethod
     def load_from_env(cls, env: Optional[Mapping[str, str]] = None) -> "Config":
@@ -171,9 +172,8 @@ class Config:
             platform_config_url=URL(env["NP_PLATFORM_CONFIG_URL"]),
             platform_api_url=URL(env["NP_PLATFORM_API_URL"]),
             platform_namespace=env["NP_PLATFORM_NAMESPACE"],
-            platform_consul_url=URL.build(
-                scheme="http", host=platform_release_name + "-consul", port=8500
-            ),
+            consul_url=URL(env["NP_CONSUL_URL"]),
+            consul_installed=env.get("NP_CONSUL_INSTALLED", "false").lower() == "true",
         )
 
     @classmethod
@@ -358,6 +358,8 @@ class PlatformConfig:
     docker_registry: DockerRegistry
     grafana_username: str
     grafana_password: str
+    consul_url: URL
+    consul_install: bool
     monitoring_logs_bucket_name: str = ""
     monitoring_metrics_bucket_name: str = ""
     monitoring_metrics_storage_class_name: str = ""
@@ -612,6 +614,8 @@ class PlatformConfigFactory:
             docker_registry=self._create_docker_registry(cluster),
             grafana_username=cluster["credentials"]["grafana"]["username"],
             grafana_password=cluster["credentials"]["grafana"]["password"],
+            consul_url=self._config.consul_url,
+            consul_install=not self._config.consul_installed,
             gcp=(
                 self._create_gcp(platform_body["spec"], cluster)
                 if cluster.cloud_provider_type == "gcp"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -55,7 +55,8 @@ def config() -> Config:
         platform_config_url=URL("https://dev.neu.ro"),
         platform_api_url=URL("https://dev.neu.ro"),
         platform_namespace="platform",
-        platform_consul_url=URL("http://platform-consul:8500"),
+        consul_url=URL("http://consul:8500"),
+        consul_installed=True,
     )
 
 
@@ -486,6 +487,8 @@ def gcp_platform_config(
         ),
         grafana_username="admin",
         grafana_password="grafana_password",
+        consul_url=URL("http://consul:8500"),
+        consul_install=False,
         gcp=GcpConfig(
             project="project",
             region="us-central1",

--- a/tests/unit/test_helm_values.py
+++ b/tests/unit/test_helm_values.py
@@ -56,12 +56,12 @@ class TestHelmValuesFactory:
                 "registryHost": f"registry.{cluster_name}.org.neu.ro",
             },
             "ingressController": {"enabled": True},
+            "consulEnabled": False,
             "jobs": {
                 "namespace": {"create": True, "name": "platform-jobs"},
                 "label": "platform.neuromation.io/job",
             },
             "storage": {"type": "nfs", "nfs": {"server": "192.168.0.3", "path": "/"}},
-            "consul": mock.ANY,
             "traefik": mock.ANY,
             "adjust-inotify": mock.ANY,
             "nvidia-gpu-driver-gcp": mock.ANY,
@@ -73,6 +73,15 @@ class TestHelmValuesFactory:
             "platform-reports": mock.ANY,
             "platform-disk-api": mock.ANY,
         }
+
+    def test_create_gcp_platform_values_with_consul(
+        self, gcp_platform_config: PlatformConfig, factory: HelmValuesFactory
+    ) -> None:
+        result = factory.create_platform_values(
+            replace(gcp_platform_config, consul_install=True)
+        )
+
+        assert result["consul"]
 
     def test_create_gcp_platform_values_with_kubernetes_storage(
         self, gcp_platform_config: PlatformConfig, factory: HelmValuesFactory
@@ -378,7 +387,7 @@ class TestHelmValuesFactory:
             "kvprovider": {
                 "consul": {
                     "watch": True,
-                    "endpoint": "platform-consul:8500",
+                    "endpoint": "http://consul:8500",
                     "prefix": "traefik",
                 },
                 "storeAcme": True,

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -52,6 +52,8 @@ class TestConfig:
             "NP_HELM_OBS_CSI_DRIVER_CHART_VERSION": "2.0.0",
             "NP_PLATFORM_NAMESPACE": "platform",
             "NP_PLATFORM_JOBS_NAMESPACE": "platform-jobs",
+            "NP_CONSUL_URL": "http://consul:8500",
+            "NP_CONSUL_INSTALLED": "true",
         }
         assert Config.load_from_env(env) == Config(
             log_level="DEBUG",
@@ -88,7 +90,8 @@ class TestConfig:
             platform_config_url=URL("http://platformconfig:8080"),
             platform_api_url=URL("http://platformapi:8080"),
             platform_namespace="platform",
-            platform_consul_url=URL("http://platform-consul:8500"),
+            consul_url=URL("http://consul:8500"),
+            consul_installed=True,
         )
 
     def test_config_defaults(self) -> None:
@@ -112,6 +115,7 @@ class TestConfig:
             "NP_HELM_OBS_CSI_DRIVER_CHART_VERSION": "2.0.0",
             "NP_PLATFORM_NAMESPACE": "platform",
             "NP_PLATFORM_JOBS_NAMESPACE": "platform-jobs",
+            "NP_CONSUL_URL": "http://consul:8500",
         }
         assert Config.load_from_env(env) == Config(
             log_level="INFO",
@@ -142,7 +146,8 @@ class TestConfig:
             platform_config_url=URL("http://platformconfig:8080"),
             platform_api_url=URL("http://platformapi:8080"),
             platform_namespace="platform",
-            platform_consul_url=URL("http://platform-consul:8500"),
+            consul_url=URL("http://consul:8500"),
+            consul_installed=False,
         )
 
 


### PR DESCRIPTION
Moved `consul` from `platform` helm chart to `platform-operator`. `platform-operator` requires consul to make distributed locks.
`consul` is left inside `platform` helm chart for backward compatibility with currently deployed clusters.