### PR TITLE
Use separate priority class for crds, do not preempt other pods 

### DIFF
--- a/charts/platform-operator/templates/crds-job.yaml
+++ b/charts/platform-operator/templates/crds-job.yaml
@@ -13,7 +13,7 @@ spec:
     spec:
       restartPolicy: Never
       serviceAccountName: {{ include "platformOperator.fullname" . }}-crds
-      priorityClassName: {{ .Release.Namespace }}-services
+      priorityClassName: {{ .Release.Namespace }}-operator-hook
       containers:
         - name: update-crds
           image: {{ .Values.kubectlImage.repository }}:{{ .Values.kubectlImage.tag }}

--- a/charts/platform-operator/templates/operator-hook-priority-class.yaml
+++ b/charts/platform-operator/templates/operator-hook-priority-class.yaml
@@ -1,8 +1,12 @@
 apiVersion: scheduling.k8s.io/v1
 kind: PriorityClass
 metadata:
-  name: {{ .Release.Namespace }}-services
+  name: {{ .Release.Namespace }}-operator-hook
   labels: {{ include "platformOperator.labels.standard" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation
+    "helm.sh/hook-weight": "-1"
 value: 1000
 globalDefault: false
 preemptionPolicy: Never


### PR DESCRIPTION
Now platform services and operator CRDs jobs will not preempt jobs, and priority class for operator-crd will be created before the operator itself is created. 