### PR TITLE
adjust inotify max instances

### DIFF
--- a/charts/platform/templates/adjust-inotify-daemon-set.yaml
+++ b/charts/platform/templates/adjust-inotify-daemon-set.yaml
@@ -27,6 +27,7 @@ spec:
           echo "inotify status BEFORE changes:\n"
           sysctl -a | grep inotify
           echo
+          sysctl -w fs.inotify.max_user_instances={{ .Values.inotify.maxInstances }}
           sysctl -w fs.inotify.max_user_watches={{ .Values.inotify.maxWatchers }}
           echo
           echo "inotify status AFTER changes:\n"
@@ -36,6 +37,7 @@ spec:
       containers:
       - name: pause
         image: {{ .Values.pauseImage.repository }}:{{ .Values.pauseImage.tag }}
-      restartPolicy: Always
   updateStrategy:
-    type: OnDelete
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1

--- a/charts/platform/values.yaml
+++ b/charts/platform/values.yaml
@@ -29,6 +29,7 @@ nodeLabels:
   job: platform.neuromation.io/job
 
 inotify:
+  maxInstances: 65536
   maxWatchers: 65536
 
 nvidiaGpuDriver:


### PR DESCRIPTION
`fluent-bit` is failing to start on new onprem clusters without `max_user_instances` update.