### PR TITLE
pass fqdn values to platform dns config

### DIFF
--- a/platform_operator/models.py
+++ b/platform_operator/models.py
@@ -860,27 +860,27 @@ class PlatformConfig:
                 (
                     ARecord(
                         name=f"{self.ingress_dns_name}.",
-                        dns_name=ingress_host,
+                        dns_name=f"{ingress_host}.",
                         zone_id=ingress_zone_id,
                     ),
                     ARecord(
                         name=f"*.jobs.{self.ingress_dns_name}.",
-                        dns_name=ingress_host,
+                        dns_name=f"{ingress_host}.",
                         zone_id=ingress_zone_id,
                     ),
                     ARecord(
                         name=f"*.apps.{self.ingress_dns_name}.",
-                        dns_name=ingress_host,
+                        dns_name=f"{ingress_host}.",
                         zone_id=ingress_zone_id,
                     ),
                     ARecord(
                         name=f"registry.{self.ingress_dns_name}.",
-                        dns_name=ingress_host,
+                        dns_name=f"{ingress_host}.",
                         zone_id=ingress_zone_id,
                     ),
                     ARecord(
                         name=f"metrics.{self.ingress_dns_name}.",
-                        dns_name=ingress_host,
+                        dns_name=f"{ingress_host}.",
                         zone_id=ingress_zone_id,
                     ),
                 )

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -249,27 +249,27 @@ class TestPlatformConfig:
             a_records=[
                 ARecord(
                     name=f"{dns_name}.",
-                    dns_name="traefik",
+                    dns_name="traefik.",
                     zone_id="/hostedzone/traefik",
                 ),
                 ARecord(
                     name=f"*.jobs.{dns_name}.",
-                    dns_name="traefik",
+                    dns_name="traefik.",
                     zone_id="/hostedzone/traefik",
                 ),
                 ARecord(
                     name=f"*.apps.{dns_name}.",
-                    dns_name="traefik",
+                    dns_name="traefik.",
                     zone_id="/hostedzone/traefik",
                 ),
                 ARecord(
                     name=f"registry.{dns_name}.",
-                    dns_name="traefik",
+                    dns_name="traefik.",
                     zone_id="/hostedzone/traefik",
                 ),
                 ARecord(
                     name=f"metrics.{dns_name}.",
-                    dns_name="traefik",
+                    dns_name="traefik.",
                     zone_id="/hostedzone/traefik",
                 ),
             ],


### PR DESCRIPTION
Currently DNS requests for AWS clusters are failing because Google DNS accepts only FQDN values (with trailing dot).