### PR TITLE
Spark operator

### DIFF
--- a/charts/platform/Chart.lock
+++ b/charts/platform/Chart.lock
@@ -53,6 +53,9 @@ dependencies:
 - name: pgo
   repository: oci://ghcr.io/neuro-inc/helm-charts
   version: 5.6.1
+- name: spark-operator
+  repository: https://kubeflow.github.io/spark-operator
+  version: 2.1.0
 - name: keda
   repository: https://kedacore.github.io/charts
   version: 2.16.1
@@ -62,5 +65,5 @@ dependencies:
 - name: alloy
   repository: https://grafana.github.io/helm-charts
   version: 1.0.1
-digest: sha256:5a75d46eb7e5e31fe03dfe22bed9d1379556fb18da5a7a24e0c12ce956567f2e
-generated: "2025-05-02T10:00:12.75289455+02:00"
+digest: sha256:c110d6b363e24a8630d490b457a1ad7af6d0b86232b765c1ed0c064ed5d219fc
+generated: "2025-05-13T09:26:08.719326792-03:00"

--- a/charts/platform/Chart.yaml
+++ b/charts/platform/Chart.yaml
@@ -67,7 +67,7 @@ dependencies:
     version: "5.6.1"
     repository: oci://ghcr.io/neuro-inc/helm-charts
     condition: appsPostgresOperatorEnabled
-  - name: apps-spark-operator
+  - name: spark-operator
     version: "2.1.0"
     repository: "https://kubeflow.github.io/spark-operator"
     condition: appsSparkOperatorEnabled

--- a/charts/platform/Chart.yaml
+++ b/charts/platform/Chart.yaml
@@ -67,6 +67,10 @@ dependencies:
     version: "5.6.1"
     repository: oci://ghcr.io/neuro-inc/helm-charts
     condition: appsPostgresOperatorEnabled
+  - name: apps-spark-operator
+    version: "2.1.0"
+    repository: "https://kubeflow.github.io/spark-operator"
+    condition: appsSparkOperatorEnabled
   - name: keda
     version: "2.16.1"
     repository: https://kedacore.github.io/charts

--- a/charts/platform/values.yaml
+++ b/charts/platform/values.yaml
@@ -119,6 +119,7 @@ appsPostgresOperatorEnabled: false
 appsKedaEnabled: false
 lokiEnabled: true
 alloyEnabled: true
+appsSparkOperatorEnabled: false
 
 tags:
   gcp: false

--- a/platform_operator/helm_values.py
+++ b/platform_operator/helm_values.py
@@ -126,7 +126,9 @@ class HelmValuesFactory:
             ),
             self._chart_names.alloy: self.create_alloy_values(platform),
             self._chart_names.loki: self.create_loki_values(platform),
-            self._chart_names.spark_operator: self.create_spark_operator_values(),
+            self._chart_names.spark_operator: self.create_spark_operator_values(
+                platform
+            ),
         }
         if platform.ingress_acme_enabled:
             result["acme"] = self.create_acme_values(platform)

--- a/platform_operator/helm_values.py
+++ b/platform_operator/helm_values.py
@@ -126,6 +126,7 @@ class HelmValuesFactory:
             ),
             self._chart_names.alloy: self.create_alloy_values(platform),
             self._chart_names.loki: self.create_loki_values(platform),
+            self._chart_names.spark_operator: self.create_spark_operator_values(),
         }
         if platform.ingress_acme_enabled:
             result["acme"] = self.create_acme_values(platform)
@@ -2365,4 +2366,8 @@ class HelmValuesFactory:
             "priorityClassName": platform.services_priority_class_name,
         }
         result.update(**self._create_tracing_values(platform))
+        return result
+
+    def create_spark_operator_values(self, platform: PlatformConfig) -> dict[str, Any]:
+        result: dict[str, Any] = {"spark": {"jobNamespaces": None}}
         return result

--- a/platform_operator/helm_values.py
+++ b/platform_operator/helm_values.py
@@ -38,6 +38,9 @@ class HelmValuesFactory:
             "appsPostgresOperatorEnabled": (
                 platform.apps_operator_config.postgres_operator_enabled
             ),
+            "appsSparkOperatorEnabled": (
+                platform.apps_operator_config.spark_operator_enabled
+            ),
             "appsKedaEnabled": platform.apps_operator_config.keda_enabled,
             "minioEnabled": platform.buckets.minio_install,
             "minioGatewayEnabled": platform.minio_gateway is not None,

--- a/platform_operator/models.py
+++ b/platform_operator/models.py
@@ -752,6 +752,7 @@ class BucketsConfig:
 @dataclass(frozen=True)
 class AppsOperatorsConfig:
     postgres_operator_enabled: bool = False
+    spark_operator_enabled: bool = False
     keda_enabled: bool = False
 
 

--- a/platform_operator/models.py
+++ b/platform_operator/models.py
@@ -132,6 +132,7 @@ class HelmChartNames:
     keda: str = "keda"
     alloy: str = "alloy"
     loki: str = "loki"
+    spark_operator: str = "spark-operator"
 
 
 @dataclass(frozen=True)

--- a/tests/unit/test_helm_values.py
+++ b/tests/unit/test_helm_values.py
@@ -41,6 +41,7 @@ class TestHelmValuesFactory:
             "acmeEnabled": True,
             "dockerRegistryEnabled": False,
             "appsPostgresOperatorEnabled": False,
+            "appsSparkOperatorEnabled": False,
             "appsKedaEnabled": False,
             "minioEnabled": False,
             "minioGatewayEnabled": True,
@@ -192,6 +193,7 @@ class TestHelmValuesFactory:
             "platform-metadata": mock.ANY,
             "loki": mock.ANY,
             "alloy": mock.ANY,
+            "spark-operator": mock.ANY,
         }
 
     def test_create_gcp_platform_with_ssl_cert(

--- a/tests/unit/test_helm_values.py
+++ b/tests/unit/test_helm_values.py
@@ -372,6 +372,7 @@ class TestHelmValuesFactory:
         assert result["dockerRegistryEnabled"] is True
         assert result["appsKedaEnabled"] is False
         assert result["appsPostgresOperatorEnabled"] is False
+        assert result["appsSparkOperatorEnabled"] is False
         assert "docker-registry" in result
         assert result["minioEnabled"] is True
         assert (


### PR DESCRIPTION
This pull request introduces support for configuring the Spark Operator in the platform's Helm chart and associated configurations. The changes include updates to the Helm chart dependencies, configuration files, and relevant Python code for managing and testing the new feature.

### Helm Chart Updates:
* Added `apps-spark-operator` as a new dependency in the `Chart.yaml` file with version `2.1.0` and a condition `appsSparkOperatorEnabled`.

### Configuration Updates:
* Introduced the `appsSparkOperatorEnabled` flag in the `values.yaml` file, defaulting to `false`.

### Python Code Updates:
* Updated `platform_operator/helm_values.py` to include `appsSparkOperatorEnabled` in the generated Helm values based on the platform configuration.
* Added `spark_operator_enabled` as a new field in the `AppsOperatorsConfig` dataclass in `platform_operator/models.py`, defaulting to `false`.

### Testing Updates:
* Extended the unit test `test_create_on_prem_platform_values` in `tests/unit/test_helm_values.py` to validate the inclusion of the `appsSparkOperatorEnabled` flag.