### PR TITLE
IT-13-Fix-Keda-autoscaler-deployment

### DIFF
--- a/charts/platform/tests/__snapshot__/keda-add-ons-http-application_test.yaml.snap
+++ b/charts/platform/tests/__snapshot__/keda-add-ons-http-application_test.yaml.snap
@@ -19,6 +19,10 @@ should match snapshot:
         helm:
           releaseName: keda-add-ons-http
           valuesObject:
+            images:
+              kubeRbacProxy:
+                repository: registry.k8s.io/kube-rbac-proxy/kube-rbac-proxy
+                tag: v0.15.0
             interceptor:
               replicas:
                 min: 1
@@ -26,7 +30,7 @@ should match snapshot:
             scaler:
               replicas: 1
         repoURL: https://kedacore.github.io/charts
-        targetRevision: 0.10.0
+        targetRevision: 0.11.1
       syncPolicy:
         automated:
           prune: false

--- a/charts/platform/tests/__snapshot__/keda-add-ons-http-application_test.yaml.snap
+++ b/charts/platform/tests/__snapshot__/keda-add-ons-http-application_test.yaml.snap
@@ -30,7 +30,7 @@ should match snapshot:
             scaler:
               replicas: 1
         repoURL: https://kedacore.github.io/charts
-        targetRevision: 0.11.1
+        targetRevision: 0.14.0
       syncPolicy:
         automated:
           prune: false

--- a/charts/platform/tests/__snapshot__/keda-application_test.yaml.snap
+++ b/charts/platform/tests/__snapshot__/keda-application_test.yaml.snap
@@ -27,7 +27,7 @@ should match snapshot:
             operator:
               replicaCount: 1
         repoURL: https://kedacore.github.io/charts
-        targetRevision: 2.16.1
+        targetRevision: 2.19.0
       syncPolicy:
         automated:
           prune: false

--- a/charts/platform/values.yaml
+++ b/charts/platform/values.yaml
@@ -129,7 +129,7 @@ argocdApplications:
     repoURL: https://kedacore.github.io/charts
     chart: keda
     name: keda
-    targetRevision: "2.16.1"
+    targetRevision: "2.19.0"
     syncWave: -1
     values: {}
 
@@ -138,7 +138,7 @@ argocdApplications:
     repoURL: https://kedacore.github.io/charts
     chart: keda-add-ons-http
     name: keda-add-ons-http
-    targetRevision: "0.11.1"
+    targetRevision: "0.14.0"
     values:
       images:
         kubeRbacProxy:

--- a/charts/platform/values.yaml
+++ b/charts/platform/values.yaml
@@ -138,8 +138,12 @@ argocdApplications:
     repoURL: https://kedacore.github.io/charts
     chart: keda-add-ons-http
     name: keda-add-ons-http
-    targetRevision: "0.10.0"
-    values: {}
+    targetRevision: "0.11.1"
+    values:
+      images:
+        kubeRbacProxy:
+          repository: registry.k8s.io/kube-rbac-proxy/kube-rbac-proxy
+          tag: v0.15.0
 
   sparkOperator:
     enabled: true


### PR DESCRIPTION
This pull request updates the configuration for the `keda-add-ons-http` ArgoCD application in the `charts/platform/values.yaml` file. The main change is upgrading the chart version and specifying a new image repository and tag for `kubeRbacProxy`.

**KEDA Add-ons HTTP Application Updates:**

* Upgraded `keda-add-ons-http` chart version from `0.10.0` to `0.11.1` to ensure the deployment uses the latest features and fixes.
* Explicitly set the `kubeRbacProxy` image repository to `registry.k8s.io/kube-rbac-proxy/kube-rbac-proxy` and updated the tag to `v0.15.0` for improved security and compatibility.