### PR TITLE
IT-134: wire adminUrl and eventsUrl for the platform-registry app

### DIFF
--- a/charts/platform/templates/platform-registry-application.yaml
+++ b/charts/platform/templates/platform-registry-application.yaml
@@ -12,6 +12,8 @@ service:
 platform:
   clusterName: {{ include "platform.clusterName" . }}
   authUrl: {{ get $platformUrls "authUrl" }}
+  adminUrl: {{ printf "%s/apis/admin/v1" (get $platformUrls "adminUrl") }}
+  eventsUrl: {{ printf "%s/apis/events" (get $platformUrls "eventsUrl") }}
   token:
     {{- include "platform.token" . | nindent 4 }}
 ingress:

--- a/charts/platform/tests/__snapshot__/platform-registry-application_test.yaml.snap
+++ b/charts/platform/tests/__snapshot__/platform-registry-application_test.yaml.snap
@@ -27,8 +27,10 @@ should match snapshot:
                 - registry.test-cluster.org.apolo.us
               ingressClassName: traefik
             platform:
+              adminUrl: https://api.apolo.us/apis/admin/v1
               authUrl: https://api.apolo.us
               clusterName: test-cluster
+              eventsUrl: https://api.apolo.us/apis/events
               token:
                 valueFrom:
                   secretKeyRef:


### PR DESCRIPTION
## Problem

platform-registry-api 26.7.0 crashloops on the compute clusters (apolo-main, imdc): new pods never become Ready → Deployment "exceeded its progress deadline" → ArgoCD Degraded. (Rolled back to 24.11.1; no outage.)

## Root cause

The `platformRegistry` ArgoCD app template passed only `authUrl` + `token` to the platform-registry subchart, **not** `adminUrl`/`eventsUrl`. So the subchart fell back to its own in-cluster defaults:

```
adminUrl:  http://platform-admin:8080/apis/admin/v1
eventsUrl: http://platform-events:8080/apis/events
```

On compute clusters `platform-admin`/`platform-events` do not run (they're control-plane services). platform-registry **26.7.0** newly opens a websocket to platform-events at startup, so the in-cluster `eventsUrl` never connects and the pod crashloops. (24.11.1 had no events dependency, so the gap was invisible.)

`authUrl` was already wired to the public `apiUrl`, which is why image pulls authenticated fine on compute — only admin/events were missing.

## Fix

Derive `adminUrl` and `eventsUrl` from the platform URLs (public `apiUrl`), exactly like `platform-secrets` and `platform-api-poller` already do:

```yaml
adminUrl: {{ printf "%s/apis/admin/v1" (get $platformUrls "adminUrl") }}
eventsUrl: {{ printf "%s/apis/events" (get $platformUrls "eventsUrl") }}
```

`helm template` renders the registry app with `eventsUrl: https://api.apolo.us/apis/events` and `adminUrl: https://api.apolo.us/apis/admin/v1` — both reachable through the control-plane ingress. The events client connects to `…/apis/events/v1/stream`, matching the platform-events ingress path `/apis/events/v1`. `platform-secrets` (also deployed on compute) already consumes events via this exact public URL, so the pattern is proven.

Refs IT-134. Complementary to neuro-inc/platform-registry-api#1187, which makes the events subscription non-fatal at startup (defense-in-depth).