### PR TITLE
IT-145: point the compute postgres operator at chart 5.8.5

### DIFF
--- a/charts/platform/tests/__snapshot__/postgres-operator-application_test.yaml.snap
+++ b/charts/platform/tests/__snapshot__/postgres-operator-application_test.yaml.snap
@@ -24,7 +24,7 @@ should match snapshot:
               - name: pgo
                 replicas: 1
         repoURL: ghcr.io/neuro-inc/app-crunchy-postgres
-        targetRevision: 5.8.3
+        targetRevision: 5.8.5
       syncPolicy:
         automated:
           prune: false

--- a/charts/platform/values.yaml
+++ b/charts/platform/values.yaml
@@ -158,7 +158,7 @@ argocdApplications:
     repoURL: ghcr.io/neuro-inc/app-crunchy-postgres
     chart: pgo
     name: postgres-operator
-    targetRevision: "5.8.3"
+    targetRevision: "5.8.5"
     values: {}
 
   platformCommon:


### PR DESCRIPTION
Brings the compute clusters to the same operator chart dev already runs.

```diff
   postgresOperator:
-    targetRevision: "5.8.3"
+    targetRevision: "5.8.5"
```

Chart published from [app-crunchy-postgres#58](https://github.com/neuro-inc/app-crunchy-postgres/pull/58). Operator image becomes `ubi9-5.8.5-0`; the bundled CRDs move to 5.8.5, which raises `postgresVersion` maximum to **18** and adds `postgres_15` / `postgres_18` images.

## Already verified on dev

Deployed there today ([cloud-infra#504](https://github.com/neuro-inc/cloud-infra/pull/504)):

```
operator:   ubi9-5.8.5-0, 1/1
CRD:        5.8.5, postgresVersion maximum 18
Application: Synced / Healthy, all 8 resources
pre-existing PostgresCluster: 4/4 Running, untouched
```

## Deliberately no `ServerSideApply` option here

The `postgresclusters` CRD is ~1.3 MB, so Argo CD's default client-side apply cannot patch it — it exceeds the 262144-byte `last-applied-configuration` limit. On dev this is solved by `sync_options = ["ServerSideApply=true"]` ([cloud-infra#508](https://github.com/neuro-inc/cloud-infra/pull/508)).

That option **cannot** be used for compute yet:

| | Argo CD | `ServerSideApply` |
|---|---|---|
| dev-gke | v3.4.6 | safe — verified |
| prod-gke (manages 59 Applications on apolo-main + imdc) | **v2.11.0** | aborts comparison for the whole application |

On v2.11 the server-side diff dies on `.status.terminatingReplicas: field not declared in schema` — that is what forced the revert in [cloud-infra#502](https://github.com/neuro-inc/cloud-infra/pull/502). [IT-44](https://apolocloud.atlassian.net/browse/IT-44) upgraded dev only.

**So rolling this out needs a manual sync with Server-Side Apply ticked** for the `postgresclusters` CRD, exactly as was done on `apolo-main` on 2026-05-12. Without it, the operator and the three small CRDs will sync and that one CRD will sit `OutOfSync` — non-destructive, but it silently recreates the image/schema drift this ticket exists to remove.

Worth adding a prod-gke phase to IT-44 so this stops being manual.

## Verification

`helm unittest charts/platform` — 25/25 pass. The snapshot was regenerated with `-u`; its only diff is the revision:

```diff
-        targetRevision: 5.8.3
+        targetRevision: 5.8.5
```

`pre-commit run --all-files` clean.

## Rollout

Merging does not ship this. It needs a release tag, then `platform_version` bumped in the HCP workspace and a staged `terraform apply -target='argocd_application.platform["<cluster>"]'` — imdc first, then apolo-main.

[IT-44]: https://apolocloud.atlassian.net/browse/IT-44?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ