### PR TITLE
IT-157: add seaweedfs as a platform chart subapp

### DIFF
--- a/charts/platform/templates/seaweedfs-application.yaml
+++ b/charts/platform/templates/seaweedfs-application.yaml
@@ -1,0 +1,61 @@
+{{- define "platform.argocd.applications.seaweedfs.values" -}}
+master:
+  data:
+    type: persistentVolumeClaim
+    size: 10Gi
+    {{- with .Values.defaultStorageClassName }}
+    storageClass: {{ . }}
+    {{- end }}
+  logs:
+    type: emptyDir
+  priorityClassName: {{ include "platform.priorityClassName" . }}
+volume:
+  dataDirs:
+  - name: data
+    type: persistentVolumeClaim
+    size: 100Gi
+    {{- with .Values.defaultStorageClassName }}
+    storageClass: {{ . }}
+    {{- end }}
+    maxVolumes: 0
+  priorityClassName: {{ include "platform.priorityClassName" . }}
+filer:
+  data:
+    type: persistentVolumeClaim
+    size: 20Gi
+    {{- with .Values.defaultStorageClassName }}
+    storageClass: {{ . }}
+    {{- end }}
+  logs:
+    type: emptyDir
+  priorityClassName: {{ include "platform.priorityClassName" . }}
+s3:
+  enabled: true
+  port: 9000
+  enableAuth: true
+  existingConfigSecret: seaweedfs-s3-secret
+  extraArgs:
+  - -iam.readOnly=false
+  extraEnvironmentVars:
+    WEED_JWT_FILER_SIGNING_KEY:
+      secretKeyRef:
+        name: seaweedfs-s3-secret
+        key: signing_key
+  logs:
+    type: emptyDir
+  internalTrafficPolicy: Cluster
+  priorityClassName: {{ include "platform.priorityClassName" . }}
+  ingress:
+    enabled: true
+    {{- with .Values.defaultIngressClassName }}
+    className: {{ . }}
+    {{- end }}
+    host: blob.{{ include "platform.clusterDnsName" . }}
+{{- end }}
+
+{{- if .Values.argocdApplications.seaweedfs.enabled }}
+{{- $cfg := deepCopy .Values.argocdApplications.seaweedfs -}}
+{{- $_ := set $cfg "root" . -}}
+{{- $_ := set $cfg "defaultValues" (include "platform.argocd.applications.seaweedfs.values" . | fromYaml) -}}
+{{- include "platform.argocd.application" $cfg }}
+{{- end }}

--- a/charts/platform/tests/__snapshot__/seaweedfs-application_test.yaml.snap
+++ b/charts/platform/tests/__snapshot__/seaweedfs-application_test.yaml.snap
@@ -1,0 +1,79 @@
+should match snapshot:
+  1: |
+    apiVersion: argoproj.io/v1alpha1
+    kind: Application
+    metadata:
+      annotations:
+        argocd.argoproj.io/sync-wave: "-20"
+      labels:
+        app: platform
+        chart: platform-1.0.0
+        heritage: Helm
+        release: platform
+      name: test-cluster--seaweedfs
+    spec:
+      destination:
+        namespace: platform
+        server: https://kubernetes.default.svc
+      project: default
+      source:
+        chart: seaweedfs
+        helm:
+          releaseName: seaweedfs
+          valuesObject:
+            filer:
+              data:
+                size: 20Gi
+                storageClass: standard
+                type: persistentVolumeClaim
+              logs:
+                type: emptyDir
+              priorityClassName: platform-services
+            master:
+              data:
+                size: 10Gi
+                storageClass: standard
+                type: persistentVolumeClaim
+              logs:
+                type: emptyDir
+              priorityClassName: platform-services
+            s3:
+              enableAuth: true
+              enabled: true
+              existingConfigSecret: seaweedfs-s3-secret
+              extraArgs:
+                - -iam.readOnly=false
+              extraEnvironmentVars:
+                WEED_JWT_FILER_SIGNING_KEY:
+                  secretKeyRef:
+                    key: signing_key
+                    name: seaweedfs-s3-secret
+              ingress:
+                className: traefik
+                enabled: true
+                host: blob.test-cluster.org.apolo.us
+              internalTrafficPolicy: Cluster
+              logs:
+                type: emptyDir
+              port: 9000
+              priorityClassName: platform-services
+            volume:
+              dataDirs:
+                - maxVolumes: 0
+                  name: data
+                  size: 100Gi
+                  storageClass: standard
+                  type: persistentVolumeClaim
+              priorityClassName: platform-services
+        repoURL: https://seaweedfs.github.io/seaweedfs/helm
+        targetRevision: 4.41.0
+      syncPolicy:
+        automated:
+          prune: false
+          selfHeal: false
+        managedNamespaceMetadata:
+          annotations:
+            argocd.argoproj.io/sync-options: Delete=false
+        syncOptions:
+          - CreateNamespace=true
+          - PrunePropagationPolicy=foreground

--- a/charts/platform/tests/seaweedfs-application_test.yaml
+++ b/charts/platform/tests/seaweedfs-application_test.yaml
@@ -1,0 +1,18 @@
+suite: test seaweedfs application
+release:
+  name: platform
+  namespace: platform
+templates:
+  - seaweedfs-application.yaml
+values:
+  - common-values.yaml
+tests:
+  - it: should match snapshot
+    set:
+      argocdApplications.seaweedfs.enabled: true
+    asserts:
+      - matchSnapshot: {}
+  - it: should render nothing when disabled
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/charts/platform/values.yaml
+++ b/charts/platform/values.yaml
@@ -65,6 +65,15 @@ argocdApplications:
     syncWave: -20
     values: {}
 
+  seaweedfs:
+    enabled: false
+    repoURL: https://seaweedfs.github.io/seaweedfs/helm
+    chart: seaweedfs
+    name: seaweedfs
+    targetRevision: "4.41.0"
+    syncWave: -20
+    values: {}
+
   thanos:
     enabled: true
     repoURL: https://neuro-inc.github.io/helm-charts


### PR DESCRIPTION
First step of [IT-157](https://apolocloud.atlassian.net/browse/IT-157). Adds seaweedfs to the platform chart the same way minio is wired, and **skips the forked chart the ticket asked for** — reasoning below, since that changes the ticket's plan.

## Why

Object storage currently arrives per cluster rather than through the chart:

* **alfa** — an Ansible playbook installs upstream chart `4.41.0` directly
* **dev** — a terraform `helm_release` in cloud-infra
* every other component — an Argo CD application from the platform chart

So the shape drifts between clusters, and neither install is reproducible from the chart. Dev's copy is also the one that cannot be applied at all right now (IT-159).

## Why no fork

The ticket's first item is a forked chart, mirroring minio. That premise does not carry over:

* The **minio** fork exists because upstream *removed* the chart. Ours is `deprecated: true` and pinned to a 2022 image — we forked it to keep something that no longer exists.
* **Seaweedfs is maintained**, and the one defect that would have justified a patch is already fixed upstream. Chart `4.0.393` hardcoded the namespace in the cluster addresses — the bug we hit on dev, where every pod pointed at `seaweedfs-filer-client.seaweedfs:8888` in a namespace that does not exist. In `4.41.0` those values are computed:

  ```
  WEED_CLUSTER_SW_MASTER: "{{ include "seaweedfs.cluster.masterAddress" . }}"
  ```
  ```
  {{- printf "%s.%s:%d" (include "seaweedfs.componentName" ...) .Release.Namespace ... -}}
  ```

  Rendered into `platform`, that gives `seaweedfs-master.platform:9333`. Correct.

A fork with nothing to patch buys only maintenance cost and drift from upstream, and the version is pinned by `targetRevision` either way. Worth revisiting the moment we actually need to carry a patch.

## What it renders

Release name `seaweedfs`, so services keep the names consumers already use — `seaweedfs-s3` and friends, which is what `platform-buckets` points at today. Ingress uses the same vendor-agnostic `blob.<cluster-dns>` minio already uses. Defaults follow alfa's working configuration (`-iam.readOnly=false` for the STS federation tokens `buckets-api` issues, JWT signing key, `internalTrafficPolicy: Cluster`), with storage class, ingress class and priority class taken from the usual chart values.

Verified by snapshot; full suite green — 42 suites, 50 snapshots.

## Deliberately not in this PR

**Disabled by default.** Nothing changes for existing clusters until someone enables it. Making it the default *instead of* minio is a separate decision that carries a data migration, same as the Loki/Mimir question in IT-39.

**Secret provisioning is unchanged.** `existingConfigSecret: seaweedfs-s3-secret` matches what alfa and dev already supply — alfa via Ansible, dev via Vault + External Secrets. Unifying that is the natural next step but it is a design decision, not a mechanical move, so it is not being made silently here.

Worth noting for whoever takes it: alfa's secret carries a `policies` / `PlatformBucketsAdmin` block that dev's does not, and dev passes the full `apolo blob` surface — 24/24, including `mkcredentials` and `sign-url`. So the simpler shape looks sufficient and the extra policies may be unnecessary.

**Production topology is not addressed.** The ticket asks for 3 masters, 3 volume pods and encryption at rest. alfa does not have that either — it runs single replicas. Defaults here are deliberately modest (100Gi volume) so that enabling it does not silently provision a lot of disk; clusters that need alfa's 10Ti override it.


[IT-157]: https://apolocloud.atlassian.net/browse/IT-157?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ